### PR TITLE
Fix rounding/overflow with SecondsToTime

### DIFF
--- a/RoomServiceLuaFunctions.cs
+++ b/RoomServiceLuaFunctions.cs
@@ -1475,6 +1475,9 @@ namespace RoomService
 
             // Calculate fractional seconds and format milliseconds with precision
             double fractionalSeconds = time - Math.Floor(time);
+            // If it rounds to 1000, reset it to 0 to avoid overflow
+            if (Math.Round(fractionalSeconds * Math.Pow(10, precision)) >= Math.Pow(10, precision))
+                fractionalSeconds = 0;
             string milliseconds = Math.Round(fractionalSeconds * Math.Pow(10, precision))
                 .ToString(CultureInfo.InvariantCulture).PadLeft(precision, '0');
 


### PR DESCRIPTION
If a time had a value such as 1.9995 this would cause the fractional seconds to overflow to 1000 then this value would get truncated resulting in a value of 2.100 instead of 2.000